### PR TITLE
Fix postView changing currentPost

### DIFF
--- a/site/components/PostsViewComponent.js
+++ b/site/components/PostsViewComponent.js
@@ -14,16 +14,9 @@ const PostsViewComponent = ({ isExiting, onClose, posts, userData, isLoadingPost
   const [audioContext, setAudioContext] = useState(null);
   const [comment, setComment] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [localPosts, setLocalPosts] = useState([]);
+  const [localPosts, setLocalPosts] = useState(Array.isArray(posts) ? posts : []);
   const [expandedPosts, setExpandedPosts] = useState({});
   const [hasToken, setHasToken] = useState(false);
-
-  // Initialize the local posts state from props
-  useEffect(() => {
-    if (posts && posts.length > 0) {
-      setLocalPosts(posts);
-    }
-  }, [posts]);
 
   // Only fetch posts if we don't have any and they're not already being loaded
   useEffect(() => {


### PR DESCRIPTION
The PostsViewComponent tries to fetch all the posts from the DB if it doesnt have any other posts to show
```ts
  // Only fetch posts if we don't have any and they're not already being loaded
  useEffect(() => {
    const fetchAllPosts = async () => {
      if (localPosts.length === 0 && !isLoadingPosts) {
        try {
          const res = await fetch("/api/getLatestPosts");
          if (res.ok) {
            const data = await res.json();
            setLocalPosts(data.posts || []);
          }
        } catch (e) {
          console.error("Error fetching all posts:", e);
        }
      }
    };

    fetchAllPosts();
  }, [localPosts.length, isLoadingPosts]);
  ```
  
This makes sense, but to do this it checks the length of `localPosts`, which is initiallized as being an empty array. Its only first being set in a different useEffect hook, meaning its basically a race condition which useEffect runs first and if localPosts has already been set when it checks.
```ts
  // Initialize the local posts state from props
  useEffect(() => {
    if (posts && posts.length > 0) {
      setLocalPosts(posts);
    }
  }, [posts]);
```
this means that it sometimes starts fetching all the posts the moment someone opens the link, and when it then finishes fetching, it updates localPosts and just shows the latest post.

I simply fixed this by initiallizing `localPosts` with the posts prop from the start. It didnt have to be in a useEffect anyway.
```ts
const [localPosts, setLocalPosts] = useState(Array.isArray(posts) ? posts : []);
```